### PR TITLE
Add RELEASE_HASH to update the containers and rename all to labeled versions

### DIFF
--- a/build-all.zsh
+++ b/build-all.zsh
@@ -15,7 +15,7 @@
 
 RELEASE_HASH=$(curl -s https://api.github.com/repos/iterative/dvc/releases/latest | sha256sum)
 
-TAGPREFIX=emresult
+TAGPREFIX=dvcorg
 DIR=$(dirname $0)
 
 find $DIR -name Dockerfile | sort | while read -r filepath ; do

--- a/build-all.zsh
+++ b/build-all.zsh
@@ -13,8 +13,9 @@
 #
 # docker build command uses --no-cache option to prevent stale layers to be used. 
 
+RELEASE_HASH=$(curl -s https://api.github.com/repos/iterative/dvc/releases/latest | sha256sum)
 
-TAGPREFIX=dvcorg
+TAGPREFIX=emresult
 DIR=$(dirname $0)
 
 find $DIR -name Dockerfile | sort | while read -r filepath ; do
@@ -25,7 +26,7 @@ find $DIR -name Dockerfile | sort | while read -r filepath ; do
         TAG=$(echo "${${filepath:h}[3,100]}" | tr '/ ' '--')
     fi
     echo "BUILDING: ${filepath} with the tag: ${TAGPREFIX}/${TAG}"
-    docker build --no-cache -t ${TAGPREFIX}/${TAG} ${filepath:h}
+    docker build --build-arg RELEASE_HASH=${RELEASE_HASH} -t ${TAGPREFIX}/${TAG} ${filepath:h}
     echo "PUSHING: ${filepath} with the tag: ${TAGPREFIX}/${TAG}"
     docker push ${TAGPREFIX}/${TAG}
 done

--- a/katacoda/Dockerfile
+++ b/katacoda/Dockerfile
@@ -2,7 +2,9 @@ FROM ubuntu:20.04
 
 WORKDIR /root
 
-RUN apt-get update -y && apt-get install -y \
+ARG RELEASE_HASH
+RUN RELEASE_HASH=${RELEASE_HASH} \
+    apt-get update -y && apt-get install -y \
                          gnupg \
                          wget \
                          tree
@@ -13,8 +15,9 @@ RUN wget \
 
 RUN wget -qO - https://dvc.org/deb/iterative.asc | apt-key add -
 
-RUN apt-get update -y && apt-get install -y \
-                         dvc 
+RUN RELEASE_HASH=${RELEASE_HASH} \
+    apt-get update -y && apt-get install -y \
+                                 dvc 
 
 COPY bashrc .bashrc
 

--- a/katacoda/Dockertag
+++ b/katacoda/Dockertag
@@ -1,1 +1,1 @@
-katacoda-base
+doc-katacoda:base

--- a/katacoda/get-started/01-initialize/Dockerfile
+++ b/katacoda/get-started/01-initialize/Dockerfile
@@ -1,4 +1,4 @@
-FROM emresult/doc-katacoda:base
+FROM dvcorg/doc-katacoda:base
 
 
 RUN RELEASE_HASH=${RELEASE_HASH} \

--- a/katacoda/get-started/01-initialize/Dockerfile
+++ b/katacoda/get-started/01-initialize/Dockerfile
@@ -1,7 +1,8 @@
-FROM dvcorg/katacoda-base:latest
+FROM emresult/doc-katacoda:base
 
 
-RUN git clone https://github.com/iterative/example-get-started --branch 0-git-init
+RUN RELEASE_HASH=${RELEASE_HASH} \
+    git clone https://github.com/iterative/example-get-started --branch 0-git-init
 
 WORKDIR /root/example-get-started
 COPY start.sh /root/start.sh

--- a/katacoda/get-started/01-initialize/Dockertag
+++ b/katacoda/get-started/01-initialize/Dockertag
@@ -1,1 +1,1 @@
-doc-katacoda-gs:initialize
+doc-katacoda:start-initialize

--- a/katacoda/get-started/01-initialize/Dockertag
+++ b/katacoda/get-started/01-initialize/Dockertag
@@ -1,1 +1,1 @@
-katacoda-gs-initialize
+doc-katacoda-gs:initialize

--- a/katacoda/get-started/02-versioning/Dockerfile
+++ b/katacoda/get-started/02-versioning/Dockerfile
@@ -1,4 +1,4 @@
-FROM emresult/doc-katacoda:base
+FROM dvcorg/doc-katacoda:base
 
 RUN RELEASE_HASH=${RELEASE_HASH} \
     git clone https://github.com/iterative/example-get-started \

--- a/katacoda/get-started/02-versioning/Dockerfile
+++ b/katacoda/get-started/02-versioning/Dockerfile
@@ -1,6 +1,9 @@
-FROM emresult/katacoda-base:latest
+FROM emresult/doc-katacoda:base
 
-RUN git clone https://github.com/iterative/example-get-started --branch 1-dvc-init && git -C /root/example-get-started/ checkout -b katacoda-changes
+RUN RELEASE_HASH=${RELEASE_HASH} \
+    git clone https://github.com/iterative/example-get-started \
+    --branch 1-dvc-init \ 
+    && git -C /root/example-get-started/ checkout -b katacoda-project
 
 COPY start.sh /root/start.sh
 

--- a/katacoda/get-started/02-versioning/Dockertag
+++ b/katacoda/get-started/02-versioning/Dockertag
@@ -1,1 +1,1 @@
-doc-katacoda-gs:versioning
+doc-katacoda:start-versioning

--- a/katacoda/get-started/02-versioning/Dockertag
+++ b/katacoda/get-started/02-versioning/Dockertag
@@ -1,1 +1,1 @@
-katacoda-gs-versioning
+doc-katacoda-gs:versioning

--- a/katacoda/get-started/03-accessing/Dockerfile
+++ b/katacoda/get-started/03-accessing/Dockerfile
@@ -1,13 +1,17 @@
-FROM dvcorg/katacoda-base:latest
+FROM emresult/doc-katacoda:base
 
-RUN apt-get update -y && apt-get install -y \
+ARG RELEASE_HASH 
+RUN RELEASE_HASH=${RELEASE_HASH} \
+    apt-get update -y && apt-get install -y \
                          python3 \
                          python-is-python3 \
                          python3-pip
 
-RUN pip3 install dvc
+RUN RELEASE_HASH=${RELEASE_HASH} \
+    pip3 install dvc
 
-RUN git init /root/example-get-started
+RUN RELEASE_HASH=${RELEASE_HASH} \
+    git init /root/example-get-started
 
 WORKDIR /root/example-get-started
 

--- a/katacoda/get-started/03-accessing/Dockerfile
+++ b/katacoda/get-started/03-accessing/Dockerfile
@@ -1,4 +1,4 @@
-FROM emresult/doc-katacoda:base
+FROM dvcorg/doc-katacoda:base
 
 ARG RELEASE_HASH 
 RUN RELEASE_HASH=${RELEASE_HASH} \

--- a/katacoda/get-started/03-accessing/Dockertag
+++ b/katacoda/get-started/03-accessing/Dockertag
@@ -1,1 +1,1 @@
-katacoda-gs-accessing
+doc-katacoda-gs:accessing

--- a/katacoda/get-started/03-accessing/Dockertag
+++ b/katacoda/get-started/03-accessing/Dockertag
@@ -1,1 +1,1 @@
-doc-katacoda-gs:accessing
+doc-katacoda:start-accessing

--- a/katacoda/get-started/04-stages/Dockerfile
+++ b/katacoda/get-started/04-stages/Dockerfile
@@ -1,4 +1,4 @@
-FROM emresult/doc-katacoda:base
+FROM dvcorg/doc-katacoda:base
 
 
 ARG RELEASE_HASH

--- a/katacoda/get-started/04-stages/Dockerfile
+++ b/katacoda/get-started/04-stages/Dockerfile
@@ -1,21 +1,25 @@
-FROM dvcorg/katacoda-base:latest
+FROM emresult/doc-katacoda:base
 
 
-RUN git clone \
+ARG RELEASE_HASH
+RUN RELEASE_HASH=${RELEASE_HASH} \
+    git clone \
     https://github.com/iterative/example-get-started \
     --branch 5-source-code \ 
     && git -C /root/example-get-started \
     checkout -b katacoda-project
 
 WORKDIR /root/example-get-started
-RUN apt-get update -y \
+RUN RELEASE_HASH=${RELEASE_HASH} \
+    apt-get update -y \
     && apt-get install -y \
                python3 \
                python3-pip \
                python-is-python3 \
     && pip3 install -r src/requirements.txt
 
-RUN dvc pull \
+RUN RELEASE_HASH=${RELEASE_HASH} \
+    dvc pull \
     && head -n 12000 data/data.xml > data/data.xml.1  \
     && mv data/data.xml.1 data/data.xml \
     && dvc add data/data.xml \

--- a/katacoda/get-started/04-stages/Dockertag
+++ b/katacoda/get-started/04-stages/Dockertag
@@ -1,1 +1,1 @@
-katacoda-gs-stages
+doc-katacoda-gs:stages

--- a/katacoda/get-started/04-stages/Dockertag
+++ b/katacoda/get-started/04-stages/Dockertag
@@ -1,1 +1,1 @@
-doc-katacoda-gs:stages
+doc-katacoda:start-stages

--- a/katacoda/get-started/05-params-metrics-plots/Dockerfile
+++ b/katacoda/get-started/05-params-metrics-plots/Dockerfile
@@ -1,6 +1,8 @@
-FROM dvcorg/katacoda-base:latest
+FROM emresult/doc-katacoda:base
 
-RUN git clone \
+ARG RELEASE_HASH
+RUN RELEASE_HASH=${RELEASE_HASH} \
+    git clone \
     https://github.com/iterative/example-get-started \
     --branch 7-ml-pipeline \ 
     && git -C /root/example-get-started \
@@ -9,7 +11,8 @@ RUN git clone \
 
 WORKDIR /root/example-get-started
 
-RUN apt-get update -y \
+RUN RELEASE_HASH=${RELEASE_HASH} \
+    apt-get update -y \
     && apt-get install -y \
                python3 \
                python3-pip \
@@ -18,7 +21,8 @@ RUN apt-get update -y \
 
 
 COPY dvc.yaml dvc.yaml
-RUN dvc pull \
+RUN RELEASE_HASH=${RELEASE_HASH} \
+    dvc pull \
     && head -n 12000 data/data.xml > data/data.xml.1  \
     && mv data/data.xml.1 data/data.xml \
     && dvc add data/data.xml \

--- a/katacoda/get-started/05-params-metrics-plots/Dockerfile
+++ b/katacoda/get-started/05-params-metrics-plots/Dockerfile
@@ -1,4 +1,4 @@
-FROM emresult/doc-katacoda:base
+FROM dvcorg/doc-katacoda:base
 
 ARG RELEASE_HASH
 RUN RELEASE_HASH=${RELEASE_HASH} \

--- a/katacoda/get-started/05-params-metrics-plots/Dockertag
+++ b/katacoda/get-started/05-params-metrics-plots/Dockertag
@@ -1,1 +1,1 @@
-katacoda-gs-params
+doc-katacoda-gs:params

--- a/katacoda/get-started/05-params-metrics-plots/Dockertag
+++ b/katacoda/get-started/05-params-metrics-plots/Dockertag
@@ -1,1 +1,1 @@
-doc-katacoda-gs:params
+doc-katacoda:start-params

--- a/katacoda/get-started/06-experiments/Dockerfile
+++ b/katacoda/get-started/06-experiments/Dockerfile
@@ -1,6 +1,8 @@
-FROM dvcorg/katacoda-base:latest
+FROM emresult/doc-katacoda:base
 
-RUN git clone \
+ARG RELEASE_HASH
+RUN RELEASE_HASH=${RELEASE_HASH} \
+    git clone \
     https://github.com/iterative/example-get-started \
     --branch 8-evaluation \ 
     && git -C /root/example-get-started \
@@ -9,7 +11,8 @@ RUN git clone \
 
 WORKDIR /root/example-get-started
 
-RUN apt-get update -y \
+RUN RELEASE_HASH=${RELEASE_HASH} \
+    apt-get update -y \
     && apt-get install -y \
                python3 \
                python3-pip \
@@ -17,7 +20,8 @@ RUN apt-get update -y \
     && pip3 install -r src/requirements.txt
 
 
-RUN dvc pull \
+RUN RELEASE_HASH=${RELEASE_HASH} \
+    dvc pull \
     && head -n 12000 data/data.xml > data/data.xml.1  \
     && mv data/data.xml.1 data/data.xml \
     && dvc add data/data.xml \

--- a/katacoda/get-started/06-experiments/Dockerfile
+++ b/katacoda/get-started/06-experiments/Dockerfile
@@ -1,4 +1,4 @@
-FROM emresult/doc-katacoda:base
+FROM dvcorg/doc-katacoda:base
 
 ARG RELEASE_HASH
 RUN RELEASE_HASH=${RELEASE_HASH} \

--- a/katacoda/get-started/06-experiments/Dockertag
+++ b/katacoda/get-started/06-experiments/Dockertag
@@ -1,1 +1,1 @@
-doc-katacoda-gs:experiments
+doc-katacoda:start-experiments

--- a/katacoda/get-started/06-experiments/Dockertag
+++ b/katacoda/get-started/06-experiments/Dockertag
@@ -1,1 +1,1 @@
-katacoda-gs-experiments
+doc-katacoda-gs:experiments

--- a/start/Dockerfile
+++ b/start/Dockerfile
@@ -1,0 +1,32 @@
+FROM ubuntu:20.04
+
+WORKDIR /root
+ARG RELEASE_HASH
+RUN RELEASE_HASH=${RELEASE_HASH} \
+    apt-get update -y && apt-get install -y \
+                         gnupg \
+                         wget \
+                         tree
+
+RUN wget \
+       https://dvc.org/deb/dvc.list \
+       -O /etc/apt/sources.list.d/dvc.list
+
+RUN wget -qO - https://dvc.org/deb/iterative.asc | apt-key add -
+
+RUN RELEASE_HASH=${RELEASE_HASH} \
+    apt-get update -y && apt-get install -y \
+                         dvc 
+
+COPY bashrc .bashrc
+
+# Configure git user name and email
+RUN git config --global user.email "guest@example.com" \
+    && git config --global user.name "Guest User"
+
+CMD ["/bin/bash", "-i"]
+
+
+
+
+

--- a/start/Dockertag
+++ b/start/Dockertag
@@ -1,0 +1,1 @@
+doc-start:base

--- a/start/bashrc
+++ b/start/bashrc
@@ -1,0 +1,57 @@
+# ~/.bashrc: executed by bash(1) for non-login shells.
+
+# If not running interactively, don't do anything
+[ -z "$PS1" ] && return
+
+# don't put duplicate lines in the history. See bash(1) for more options
+# don't overwrite GNU Midnight Commander's setting of `ignorespace'.
+HISTCONTROL=$HISTCONTROL${HISTCONTROL+:}ignoredups
+# ... or force ignoredups and ignorespace
+HISTCONTROL=ignoreboth
+
+# append to the history file, don't overwrite it
+shopt -s histappend
+
+# for setting history length see HISTSIZE and HISTFILESIZE in bash(1)
+
+# check the window size after each command and, if necessary,
+# update the values of LINES and COLUMNS.
+shopt -s checkwinsize
+
+# make less more friendly for non-text input files, see lesspipe(1)
+#[ -x /usr/bin/lesspipe ] && eval "$(SHELL=/bin/sh lesspipe)"
+
+# prompt
+PS1='\[\033[01;34m\]\w\[\033[00m\]$ \[\033[01;32m\]'
+trap 'echo -ne "\033[00m"' DEBUG
+
+# enable color support of ls and also add handy aliases
+if [ -x /usr/bin/dircolors ]; then
+    test -r ~/.dircolors && eval "$(dircolors -b ~/.dircolors)" || eval "$(dircolors -b)"
+    alias ls='ls --color=auto'
+    alias dir='dir --color=auto'
+    alias vdir='vdir --color=auto'
+
+    alias grep='grep --color=auto'
+    alias fgrep='fgrep --color=auto'
+    alias egrep='egrep --color=auto'
+fi
+
+# some more ls aliases
+alias ll='ls -l'
+alias la='ls -A'
+alias l='ls -CF'
+
+# enable dvc completion
+dvc completion -s bash > /etc/bash_completion.d/dvc  
+
+# enable programmable completion features (you don't need to enable
+# this, if it's already enabled in /etc/bash.bashrc and /etc/profile
+# sources /etc/bash.bashrc).
+if [ -f /etc/bash_completion ] && ! shopt -oq posix; then
+    . /etc/bash_completion
+fi
+
+if [ -f $HOME/start.sh ] ; then
+    $HOME/start.sh 
+fi


### PR DESCRIPTION
This PR renames the repositories to `doc-katacoda` and `doc-start`. These two have the following labels corresponding to scenarios and pages: 

- `doc-katacoda:base`: The base container for all Katacoda scenarios
- `doc-katacoda:start-initialize`: The container for [Initialize Scenario](https://katacoda.com/dvc/courses/get-started/initialize)
- `doc-katacoda:start-versioning`: [Data and Model Versioning Scenario](https://katacoda.com/dvc/courses/get-started/versioning)
- `doc-katacoda:start-accessing`: [Accessing Data and Models Scenario](https://katacoda.com/dvc/courses/get-started/accessing)
- `doc-katacoda:start-stages`: [Stages and Pipelines Scenario](https://katacoda.com/dvc/courses/get-started/stages)
- `doc-katacoda:start-params`: [Params, Metrics, and Plots Scenario](https://katacoda.com/dvc/courses/get-started/params-metrics-plots)
- `doc-katacoda:start-experiments`: [Experiments Scenario](https://katacoda.com/dvc/courses/get-started/experiments)
- `doc-start:base`: A container under development for all [Get Started section](https://dvc.org/doc/start)

This PR also adds `RELEASE_HASH` to `build-all.zsh`. It checks the latest DVC release using the Github API and supplies this value to containers for them to update DVC installation layers. Previously it was using `--no-cache`, but this was suboptimal and before that new DVC versions were skipped because the changes weren't detected. 

Closes #1
Closes #3 


