### PR TITLE
Added ENV declarations to base containers for LANG and LC_ALL

### DIFF
--- a/katacoda/Dockerfile
+++ b/katacoda/Dockerfile
@@ -2,6 +2,9 @@ FROM ubuntu:20.04
 
 WORKDIR /root
 
+ENV LANG C.UTF-8
+ENV LC_ALL C.UTF-8
+
 ARG RELEASE_HASH
 RUN RELEASE_HASH=${RELEASE_HASH} \
     apt-get update -y && apt-get install -y \

--- a/start/Dockerfile
+++ b/start/Dockerfile
@@ -1,6 +1,10 @@
 FROM ubuntu:20.04
 
 WORKDIR /root
+
+ENV LANG C.UTF-8
+ENV LC_ALL C.UTF-8
+
 ARG RELEASE_HASH
 RUN RELEASE_HASH=${RELEASE_HASH} \
     apt-get update -y && apt-get install -y \


### PR DESCRIPTION
This one adds `ENV` declarations to `doc-katacoda:base` and `doc-start:base` (and their derivative containers). This should resolve the `PYTHONIOENCODING` error in iterative/katacoda-scenarios#55