### PR TITLE
Add Github Action file to run the build script regularly

### DIFF
--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -18,21 +18,30 @@ on:
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   # This workflow contains a single job called "build"
-  build:
-    # The type of runner that the job will run on
+  docker:
     runs-on: ubuntu-latest
-
-    # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
 
-      # Runs a single command using the runners shell
-      - name: Run a one-line script
-        run: ./build-all.zsh
-
-      # Runs a set of commands using the runners shell
-      - name: Run a multi-line script
-        run: |
-          echo Add other actions to build,
-          echo test, and deploy your project.
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      -
+        name: Login to DockerHub
+        uses: docker/login-action@v1 
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      -
+        name: Run build script
+        run: ./build-all.bash
+        # name: Build and push
+        # id: docker_build
+        # uses: docker/build-push-action@v2
+        # with:
+        #   push: true
+        #   tags: user/app:latest

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -1,6 +1,6 @@
 # This is a basic workflow to help you get started with Actions
 
-name: CI
+name: build-all
 
 # Controls when the action will run. 
 on:

--- a/README.md
+++ b/README.md
@@ -2,22 +2,22 @@ This repository contains `Dockerfile`s to create containers to run
 documentation examples in the [DVC documentation](https://dvc.org/doc/) and
 [Katacoda scenarios](https://katacoda.com/dvc/). 
 
-`build-all.zsh` script builds and pushes all images. To update the images, you
+`build-all.bash` script builds and pushes all images. To update the images, you
 simply need:
 
 ```bash
-./build-all.zsh
+./build-all.bash
 ```
 
-Note that `build-all.zsh` script has a `TAGPREFIX` setting which should be set
+Note that `build-all.bash` script has a `TAGPREFIX` setting which should be set
 to a Docker Hub id. The script will report errors if you don't have permission
 to push to [docker.io/dvcorg](https://docker.io/dvcorg). You can change
-`TAGPREFIX` in `build-all.zsh` to use the script to manage your own images. 
+`TAGPREFIX` in `build-all.bash` to use the script to manage your own images. 
 
 Each leaf folder contains a `Dockerfile` to build image and an (optional)
 `Dockertag` file that contains suffix portion of image id in its first line. If
-`Dockertag` file is not provided, image id for the image is produced by
-changing `<space>` and `/`s in directory name to `-`.
+`Dockertag` file is not provided, image id is produced by changing `<space>`
+and `/`s in directory name to `-`.
 
 As of April 2021, the repository contains images for Katacoda Getting Started
 scenarios.

--- a/build-all.bash
+++ b/build-all.bash
@@ -13,7 +13,9 @@
 #
 # docker build command uses --no-cache option to prevent stale layers to be used. 
 
-RELEASE_HASH=$(curl -s https://api.github.com/repos/iterative/dvc/releases/latest | sha256sum)
+set -vex
+
+RELEASE_HASH=$(curl -s https://api.github.com/repos/iterative/dvc/releases/latest | sha256sum | cut -c -8)
 
 TAGPREFIX=dvcorg
 DIR=$(dirname $0)
@@ -28,7 +30,7 @@ find $DIR -name Dockerfile | sort | while read -r filepath ; do
         TAG=$(echo "${dockerdir}[3,100]}" | tr '/ ' '--')
     fi
     echo "BUILDING: ${dockerdir} with the tag: ${TAGPREFIX}/${TAG}"
-    docker build --build-arg RELEASE_HASH=${RELEASE_HASH} -t ${TAGPREFIX}/${TAG} ${dockerdirw}
+    docker build --build-arg RELEASE_HASH=${RELEASE_HASH} -t ${TAGPREFIX}/${TAG} ${dockerdir}/
     echo "PUSHING: ${dockerdir} with the tag: ${TAGPREFIX}/${TAG}"
     docker push ${TAGPREFIX}/${TAG}
 done

--- a/build-all.bash
+++ b/build-all.bash
@@ -1,4 +1,4 @@
-#!/bin/zsh
+#!/bin/bash
 
 
 # This script builds all Docker containers described by Dockerfiles in this repository
@@ -17,16 +17,18 @@ RELEASE_HASH=$(curl -s https://api.github.com/repos/iterative/dvc/releases/lates
 
 TAGPREFIX=dvcorg
 DIR=$(dirname $0)
+cd "${DIR}"
 
 find $DIR -name Dockerfile | sort | while read -r filepath ; do
-    tagfile=${filepath:h}/Dockertag
+    dockerdir=$(dirname ${filepath})
+    tagfile=${dockerdir}/Dockertag
     if [ -f ${tagfile} ] ; then
         TAG=$(head -n 1 ${tagfile})
     else
-        TAG=$(echo "${${filepath:h}[3,100]}" | tr '/ ' '--')
+        TAG=$(echo "${dockerdir}[3,100]}" | tr '/ ' '--')
     fi
-    echo "BUILDING: ${filepath} with the tag: ${TAGPREFIX}/${TAG}"
+    echo "BUILDING: ${dockerdir} with the tag: ${TAGPREFIX}/${TAG}"
     docker build --build-arg RELEASE_HASH=${RELEASE_HASH} -t ${TAGPREFIX}/${TAG} ${filepath:h}
-    echo "PUSHING: ${filepath} with the tag: ${TAGPREFIX}/${TAG}"
+    echo "PUSHING: ${dockerdir} with the tag: ${TAGPREFIX}/${TAG}"
     docker push ${TAGPREFIX}/${TAG}
 done

--- a/build-all.bash
+++ b/build-all.bash
@@ -28,7 +28,7 @@ find $DIR -name Dockerfile | sort | while read -r filepath ; do
         TAG=$(echo "${dockerdir}[3,100]}" | tr '/ ' '--')
     fi
     echo "BUILDING: ${dockerdir} with the tag: ${TAGPREFIX}/${TAG}"
-    docker build --build-arg RELEASE_HASH=${RELEASE_HASH} -t ${TAGPREFIX}/${TAG} ${filepath:h}
+    docker build --build-arg RELEASE_HASH=${RELEASE_HASH} -t ${TAGPREFIX}/${TAG} ${dockerdirw}
     echo "PUSHING: ${dockerdir} with the tag: ${TAGPREFIX}/${TAG}"
     docker push ${TAGPREFIX}/${TAG}
 done


### PR DESCRIPTION
This update adds a `build-all.yml` file in `.github/workflows/` to run `build-all.bash` regularly. It creates a cron job to update `dvcorg/doc-*` containers everyday at 00:21 UTC. 

The following secrets should be set in the repository secrets to use this workflow: 
```
DOCKERHUB_USERNAME = dvcorg
DOCKERHUB_TOKEN = <<The access token produced for this script in https://hub.docker.com/settings/security >>
```

This also updates `build-all` script to run in bash rather than in zsh. 

Closes #6 
Related iterative/dvc.org#2355


@shcheklein 
